### PR TITLE
Fix the `inactive` to `announcing` stage transition

### DIFF
--- a/packages/ui/src/council/hooks/useElectionStage.ts
+++ b/packages/ui/src/council/hooks/useElectionStage.ts
@@ -1,5 +1,5 @@
 import { useMemo } from 'react'
-import { concatMap, map, Observable, of } from 'rxjs'
+import { concatMap, EMPTY, merge, Observable, of } from 'rxjs'
 
 import { useApi } from '@/common/hooks/useApi'
 import { useObservable } from '@/common/hooks/useObservable'
@@ -12,31 +12,32 @@ interface UseElectionStage {
 
 export const useElectionStage = (): UseElectionStage => {
   const { api } = useApi()
-  const stageObservable = useMemo(
-    () =>
-      api?.query.council.stage().pipe(
-        concatMap(({ stage: councilStage }): Observable<ElectionStage> => {
-          if (councilStage.isAnnouncing) {
-            return of('announcing')
-          } else if (councilStage.isElection) {
-            return api.query.referendum.stage().pipe(
-              map((electionStage) => {
-                if (electionStage.isVoting) {
-                  return 'voting'
-                } else if (electionStage.isRevealing) {
-                  return 'revealing'
-                } else {
-                  return 'inactive'
-                }
-              })
-            )
-          } else {
-            return of('inactive')
-          }
-        })
-      ),
-    [api]
-  )
+
+  const stageObservable = useMemo(() => {
+    if (!api) return
+
+    const councilObservable = api.query.council.stage().pipe(
+      concatMap(({ stage: councilStage }): Observable<ElectionStage> => {
+        if (councilStage.isIdle) {
+          return of('inactive')
+        } else if (councilStage.isAnnouncing) {
+          return of('announcing')
+        }
+        return EMPTY
+      })
+    )
+    const referendumObservable = api.query.referendum.stage().pipe(
+      concatMap((referendumStage): Observable<ElectionStage> => {
+        if (referendumStage.isVoting) {
+          return of('voting')
+        } else if (referendumStage.isRevealing) {
+          return of('revealing')
+        }
+        return EMPTY
+      })
+    )
+    return merge(councilObservable, referendumObservable)
+  }, [api])
 
   const stage = useObservable(stageObservable, [stageObservable])
 


### PR DESCRIPTION
@freakstatic this should fix the transaction issue between `revealing` and `announcing` and `inactive` (`idle`) and `announcing` (I think :crossed_fingers:)